### PR TITLE
Encode non-ascii cookie values with CURL

### DIFF
--- a/include/global.func.php
+++ b/include/global.func.php
@@ -695,7 +695,7 @@ function http_build_cookiedata($cookie_arr){
 	$cookiedata= '';
 	if(!empty($cookie_arr)){
 		foreach($cookie_arr as $k=> $v){
-			$cookiedata.= $k.'='.$v.'; ';//浏览器传cookie时;后有空格
+			$cookiedata.= $k.'='.urlencode($v).'; ';//浏览器传cookie时;后有空格
 		}
 		if(strlen($cookiedata)>0){
 			$cookiedata= substr($cookiedata, 0, -2);


### PR DESCRIPTION
RFC 标准不允许在 header 中直接使用非 ascii 字符。CURL 以及一众常见前端包括 IIS、Apache 以及 nginx 都支持非标准的 UTF-8 编码 header。而其他的一些前端是有可能不支持此行为的， 例如：
- https://github.com/nodejs/node /issues/17390
- https://github.com/aspnet/KestrelHttpServer /issues/1144